### PR TITLE
fix: Improves account selection by including username in remote url 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitShift
 
-[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://marketplace.visualstudio.com/items?itemName=mikeeeyy04.gitshift)
+[![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmikeeeyy04%2FGitShift%2Fmain%2Fpackage.json&query=%24.version&label=version&color=blue)](https://marketplace.visualstudio.com/items?itemName=mikeeeyy04.gitshift)
 [![VS Code Version](https://img.shields.io/badge/VS%20Code-1.90.0+-blue.svg)](https://code.visualstudio.com/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitshift",
   "displayName": "GitShift",
   "description": "Manage and seamlessly switch between multiple GitHub accounts within VS Code. Easily handle authentication, commit and push as different users, use personal access tokens, and keep your Git configuration in sync across workspaces. Ideal for developers with personal, work, or organizational GitHub accounts.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "mikeeeyy04",
   "icon": "images/icon.png",
   "homepage": "https://github.com/mikeeeyy04/GitShift",

--- a/src/gitCredentials.ts
+++ b/src/gitCredentials.ts
@@ -108,12 +108,13 @@ export async function updateRemoteUrlWithToken(remoteName: string, token: string
         const currentUrl = stdout.trim();
 
         // Parse the URL to extract owner/repo and create a CLEAN URL (no token embedded)
+        // Include username so Git credential lookup is deterministic per selected account.
         let cleanUrl: string;
 
         if (currentUrl.startsWith('git@github.com:')) {
             // Convert SSH to HTTPS (clean, no token)
             const repoPath = currentUrl.replace('git@github.com:', '').replace('.git', '');
-            cleanUrl = `https://github.com/${repoPath}.git`;
+            cleanUrl = `https://${username}@github.com/${repoPath}.git`;
         } else if (currentUrl.includes('github.com')) {
             // Remove any embedded credentials and create clean URL
             // Handle URLs like: https://username:token@github.com/owner/repo.git
@@ -130,7 +131,7 @@ export async function updateRemoteUrlWithToken(remoteName: string, token: string
             }
 
             if (repoPath) {
-                cleanUrl = `https://github.com/${repoPath}.git`;
+                cleanUrl = `https://${username}@github.com/${repoPath}.git`;
             } else {
                 throw new Error('Could not parse repository URL');
             }
@@ -265,7 +266,7 @@ export async function migrateEmbeddedCredentials(): Promise<void> {
                 if (!cleanPath.endsWith('.git')) {
                     cleanPath = cleanPath.replace(/\/$/, ''); // Remove trailing slash if present
                 }
-                const cleanUrl = `https://github.com/${cleanPath}`;
+                const cleanUrl = `https://${username}@github.com/${cleanPath}`;
                 
                 await execPromise(`git remote set-url origin "${cleanUrl}"`, {
                     cwd: workspaceRoot
@@ -277,4 +278,3 @@ export async function migrateEmbeddedCredentials(): Promise<void> {
         console.warn(`Failed to migrate embedded credentials: ${error.message}`);
     }
 }
-


### PR DESCRIPTION
This change updates GitHub remote URL normalization to preserve the selected account username in clean HTTPS remotes while still removing tokens.

In updateRemoteUrlWithToken, both SSH-to-HTTPS conversion and existing HTTPS parsing now generate remotes in the form [https://USERNAME@github.com/OWNER/REPO.git](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

In migrateEmbeddedCredentials, migrated origin URLs now also include the username prefix.

Result: Git credential matching is account-specific and more reliable when multiple GitHub accounts exist, without storing access tokens in remote URLs.